### PR TITLE
Refactor compile command parsing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "cmake-clangd-helper",
-    "version": "0.0.1",
+    "version": "0.4.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "contributors": [
         {
             "name": "Rolando J. Nieves",
-            "email": "rolando.j.nieves@nasa.gov"
+            "email": "rjnieves@embarqmail.com"
         }
     ],
     "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -2,8 +2,14 @@
     "name": "cmake-clangd-helper",
     "displayName": "cmake-clangd-helper",
     "description": "Configure clangcflags and clangcxxflags automatically from compile_commands.json using cmake",
-    "version": "0.3.0",
+    "version": "0.4.0",
     "publisher": "Harikrishnan",
+    "contributors": [
+        {
+            "name": "Rolando J. Nieves",
+            "email": "rolando.j.nieves@nasa.gov"
+        }
+    ],
     "license": "MIT",
     "homepage": "https://github.com/harikrishnan94/cmake-clangd-helper/README.md",
     "repository": {

--- a/src/c_arg_parse.ts
+++ b/src/c_arg_parse.ts
@@ -1,7 +1,7 @@
 'use strict';
 
 /**
- * Known C language standards for CLang
+ * Known C language standards supported by CLang
  * 
  * @description These were acquired from the LLVM CLang Github repository at:
  * - `clang/include/clang/Frontend/LangStandards.def`

--- a/src/c_arg_parse.ts
+++ b/src/c_arg_parse.ts
@@ -1,7 +1,12 @@
 'use strict';
 
-// These were acquired from the LLVM CLang Github repository at:
-// clang/include/clang/Frontend/LangStandards.def
+/**
+ * Known C language standards for CLang
+ * 
+ * @description These were acquired from the LLVM CLang Github repository at:
+ * - `clang/include/clang/Frontend/LangStandards.def`
+ * Accurate as of 2018-05-04
+ */
 const KNOWN_C_LANG_STDS : string[] = [
     "c89",
     "c90",
@@ -26,12 +31,51 @@ const KNOWN_C_LANG_STDS : string[] = [
     "gnu17"
 ];
 
+/**
+ * Data container for identified C compiler flags.
+ * 
+ * @description As of this writing, the only flags that will be stored on
+ * instances that implement this interface are:
+ * - C Language standard (from the menu of known supported standards to date)
+ * - Cross compilation system root directory
+ * - Cross compilation "target triple" identifier.
+ * 
+ * @author Rolando J. Nieves
+ */
 export interface CArgInfo {
+    /**
+     * C language standard detected in compile command line.
+     */
     langStandard : string;
+    /**
+     * Cross compilation system root directory detected in compile command line.
+     */
     systemRoot : string;
+    /**
+     * Cross compilation "target triple" identifier detected in compile command line.
+     * 
+     * @description This field will only be populated if the project using this
+     * extension is actually built using CLang.
+     */
     crossTarget: string;
 }
 
+/**
+ * Create `CArgInfo` instance using information from compilation command line
+ * 
+ * @description As of this writing, the only flags that will be detected by
+ * this function are:
+ * - `-std=<arg>`: C language standard. `<arg>` must identify a standard
+ *   supported by CLang as of this writing.
+ * - `--sysroot=<arg>`: Cross compilation system root directory. `<arg>` is
+ *   taken as-is.
+ * - `-target <arg>`: Cross compilation "target triple." Also detected as
+ *   `--target=<arg>`. `<arg>` is taken as-is.
+ * 
+ * @param {string} commandLine Compile command to parse.
+ * 
+ * @author Rolando J. Nieves
+ */
 export function cArgParse(commandLine : string) : CArgInfo {
     let result = {
         langStandard: null,
@@ -48,14 +92,22 @@ export function cArgParse(commandLine : string) : CArgInfo {
                 targetIncoming = false;
             } else if (aCmdArg.startsWith("-std=")) {
                 stdCandidate = aCmdArg.substr(5);
+                // We will only accept C language standards supported by CLang
+                // as of this writing.
                 if (KNOWN_C_LANG_STDS.indexOf(stdCandidate) != -1) {
                     result.langStandard = stdCandidate;
                 }
             } else if (aCmdArg.startsWith("--sysroot=")) {
                 result.systemRoot = aCmdArg.substr(10);
             } else if (aCmdArg == "-target") {
+                // Variation of target triple option split into two arguments.
+                // Next iteration will pick up the actual value. The only
+                // protection that exists against an improperly constructed
+                // compile command that is missing the actual value is that
+                // the function will not cause a runtime error.
                 targetIncoming = true;
             } else if (aCmdArg.startsWith("--target=")) {
+                // Variation of target triple that is all in one argument.
                 result.crossTarget = aCmdArg.substr(9);
             }
         }

--- a/src/c_arg_parse.ts
+++ b/src/c_arg_parse.ts
@@ -1,0 +1,65 @@
+'use strict';
+
+// These were acquired from the LLVM CLang Github repository at:
+// clang/include/clang/Frontend/LangStandards.def
+const KNOWN_C_LANG_STDS : string[] = [
+    "c89",
+    "c90",
+    "iso9899:1990",
+    "iso9899:199409",
+    "gnu89",
+    "gnu90",
+    "c99",
+    "iso9899:1999",
+    "c9x",
+    "iso9899:199x",
+    "gnu99",
+    "gnu9x",
+    "c11",
+    "iso9899:2011",
+    "c1x",
+    "iso9899:201x",
+    "gnu11",
+    "gnu1x",
+    "c17",
+    "iso9899:2017",
+    "gnu17"
+];
+
+export interface CArgInfo {
+    langStandard : string;
+    systemRoot : string;
+    crossTarget: string;
+}
+
+export function cArgParse(commandLine : string) : CArgInfo {
+    let result = {
+        langStandard: null,
+        systemRoot: null,
+        crossTarget: null
+    }
+    let stdCandidate : string = null;
+    let targetIncoming : boolean = false;
+
+    commandLine.split(" ").forEach(
+        (aCmdArg : string) : void => {
+            if (targetIncoming) {
+                result.crossTarget = aCmdArg.trim();
+                targetIncoming = false;
+            } else if (aCmdArg.startsWith("-std=")) {
+                stdCandidate = aCmdArg.substr(5);
+                if (KNOWN_C_LANG_STDS.indexOf(stdCandidate) != -1) {
+                    result.langStandard = stdCandidate;
+                }
+            } else if (aCmdArg.startsWith("--sysroot=")) {
+                result.systemRoot = aCmdArg.substr(10);
+            } else if (aCmdArg == "-target") {
+                targetIncoming = true;
+            } else if (aCmdArg.startsWith("--target=")) {
+                result.crossTarget = aCmdArg.substr(9);
+            }
+        }
+    );
+
+    return result;
+}

--- a/src/clang_cpp_flags.ts
+++ b/src/clang_cpp_flags.ts
@@ -86,14 +86,22 @@ export class clang_cpp_flags {
 	}
 
 	updateLangFlags() {
+		// Transform each entry in the `compile_commands.json` file into a
+		// `CmakeCompileCmd` instance.
 		let parsedCmds : CmakeCompileCmd[] = this.compileCommands.map(
 			(aCmakeCmd : string) : CmakeCompileCmd => {
 				return new CmakeCompileCmd(aCmakeCmd);
 			}
 		);
+
+		// Instantiate sets that will help eliminate duplicates parsed from
+		// `compile_commands.json`
 		let cFlagsSet = new Set();
 		let cxxFlagsSet = new Set();
 
+		// Based on the best-guess source language detected, populate the
+		// option sets that will eventually be fed back to CLang Adpater
+		// configuration.
 		parsedCmds.forEach(
 			(aParsedCmd : CmakeCompileCmd) : void => {
 				if (aParsedCmd.language === CmakeCompileCmd.LANG_C) {
@@ -106,6 +114,8 @@ export class clang_cpp_flags {
 			}
 		);
 
+		// Extract the result of the deduplication into the fields that will be
+		// written to the CLang Adapter configuration.
 		this.clangCFlags = Array.from(cFlagsSet);
 		this.clangCxxFlags = Array.from(cxxFlagsSet);
 	}

--- a/src/cmakecompilecmd.ts
+++ b/src/cmakecompilecmd.ts
@@ -1,0 +1,108 @@
+'use strict';
+
+import * as path from "path";
+import { cppArgParse, CppArgInfo } from "./cpp_arg_parse";
+import { cArgParse, CArgInfo } from "./c_arg_parse";
+import { cxxArgParse, CxxArgInfo } from "./cxx_arg_parse";
+
+export class CmakeCompileCmd {
+    public static LANG_C : string = "c";
+    public static LANG_CXX : string = "c++";
+    public static LANG_OBJC : string = "objc";
+    public language : string = null;
+    public cppFlags : string [] = [];
+    public cFlags : string [] = [];
+    public cxxFlags : string [] = [];
+    public objcFlags : string [] = [];
+
+    constructor(
+        cmakeJsonObj : any
+    ) {
+        // Validate the incoming object to make sure it contains at a minimum
+        // the requisite fields in the correct type.
+        if (!("directory" in cmakeJsonObj) || (typeof cmakeJsonObj.directory !== typeof "")) {
+            throw Error("CMake compile command must contain string 'directory' field.");
+        }
+
+        if (!("command" in cmakeJsonObj) || (typeof cmakeJsonObj.command !== typeof "")) {
+            throw Error("CMake compile command must contain string 'command' field.");
+        }
+
+        if (!("file" in cmakeJsonObj) || (typeof cmakeJsonObj.file !== typeof "")) {
+            throw Error("CMake compile command must contain string 'file' field.");
+        }
+
+        // Parse as much information as possible from the incoming object.
+        let preprocArgs : CppArgInfo = cppArgParse(cmakeJsonObj.command);
+        let cArgs : CArgInfo = cArgParse(cmakeJsonObj.command);
+        let cxxArgs : CxxArgInfo = cxxArgParse(cmakeJsonObj.command);
+
+        // Build up the array of preprocessor flags we're interested in: macro
+        // definitions and the include path.
+        preprocArgs.macroDefines.forEach(
+            (aMacroDef : string) : void => {
+                this.cppFlags.push("-D" + aMacroDef);
+            }
+        );
+        preprocArgs.includePath.forEach(
+            (anIncludeDir : string) : void => {
+                // It seems that when using the CMake Ninja generator, CMake
+                // places a premium on using relative paths, apparently
+                // simplifying its dependency tracking. That's not usually a
+                // problem, except that the working directory under which the
+                // CLang scanner is run is not always compatible with the
+                // relative paths. Thus, we use the "directory" field and the
+                // CMake-provided relative path to build an absolute path.
+                if (!path.isAbsolute(anIncludeDir)) {
+                    anIncludeDir = path.resolve(cmakeJsonObj.directory, anIncludeDir);
+                }
+                this.cppFlags.push("-I" + anIncludeDir);
+            }
+        );
+
+        // Build up the array of C compiler flags we're interested in: language
+        // standard, cross compilation system root, and cross compilation
+        // target triple. The last one is currently only available when CLang
+        // is used to compile the project.
+        if (cArgs.langStandard) {
+            this.cFlags.push("-std=" + cArgs.langStandard);
+        }
+        if (cArgs.systemRoot) {
+            this.cFlags.push("--sysroot=" + cArgs.systemRoot);
+        }
+        if (cArgs.crossTarget) {
+            this.cFlags.push("-target");
+            this.cFlags.push(cArgs.crossTarget);
+        }
+
+        // Build up the array of C++ compiler flags we're interested in:
+        // language standard, cross compilation system root, cross
+        // compilation target triple, and C++ standard library to use.
+        // The last two are currently only available when CLang is used to 
+        // compile the project.
+        if (cxxArgs.langStandard) {
+            this.cxxFlags.push("-std=" + cxxArgs.langStandard);
+        }
+        if (cxxArgs.systemRoot) {
+            this.cxxFlags.push("--sysroot=" + cxxArgs.systemRoot);
+        }
+        if (cxxArgs.crossTarget) {
+            this.cxxFlags.push("-target");
+            this.cxxFlags.push(cxxArgs.crossTarget);
+        }
+        if (cxxArgs.cxxStdLibrary) {
+            this.cxxFlags.push("-stdlib=" + cxxArgs.cxxStdLibrary);
+        }
+
+        // Attempt to decipher the compilation language based on the
+        // translation unit (i.e., file) extension.
+        let fileExt = path.extname(cmakeJsonObj.file);
+        if (fileExt == ".c") {
+            this.language = CmakeCompileCmd.LANG_C;
+        } else if ((fileExt == ".cc") || (fileExt == ".cxx") || (fileExt == ".cpp")) {
+            this.language = CmakeCompileCmd.LANG_CXX
+        } else if (fileExt == ".m") {
+            this.language = CmakeCompileCmd.LANG_OBJC;
+        }
+    }
+}

--- a/src/cmakecompilecmd.ts
+++ b/src/cmakecompilecmd.ts
@@ -5,16 +5,75 @@ import { cppArgParse, CppArgInfo } from "./cpp_arg_parse";
 import { cArgParse, CArgInfo } from "./c_arg_parse";
 import { cxxArgParse, CxxArgInfo } from "./cxx_arg_parse";
 
+/**
+ * Class that transforms a CMake `compile_commands` entry.
+ * 
+ * @description The transformation takes as much information as possible from
+ * the CMake `compile_commands` entry, distills only what is required for
+ * the CLang Adapter VSCode extension to work, and makes the distilled
+ * information available via fields.
+ * 
+ * @author Rolando J. Nieves
+ */
 export class CmakeCompileCmd {
+    /**
+     * Symbol used to identify C language entries.
+     */
     public static LANG_C : string = "c";
+    /**
+     * Symbol used to identify C++ language entries.
+     */
     public static LANG_CXX : string = "c++";
+    /**
+     * Symbol used to identify Objective-C language entries.
+     */
     public static LANG_OBJC : string = "objc";
+    /**
+     * Result of best effort source file language.
+     * @description Should only be one of:
+     * - `CmakeCompileCmd.LANG_C`: C source file
+     * - `CmakeCompileCmd.LANG_CXX`: C++ source file
+     * - `CmakeCompileCmd.LANG_OBJC`: Objective-C source file
+     */
     public language : string = null;
+    /**
+     * Pre-processor flags parsed from this `compile_commands` entry.
+     * @description As of this writing, will only contain macro definitions
+     * and standard include path entries.
+     */
     public cppFlags : string [] = [];
+    /**
+     * C compiler flags parsed from this `compile_commands` entry.
+     * @description As of this writing, will only contain language standard
+     * selection, and cross-compilation related flags such as target system
+     * root directory and "target triple" specification.
+     */
     public cFlags : string [] = [];
+    /**
+     * C++ compiler flags parsed from this `compile_commands` entry.
+     * @description As of this writing, will only contain language standard
+     * selection, C++ standard library selection (applicable only to CLang),
+     * and cross-compilation related flags such as target system root
+     * directory and "target triple" specification.
+     */
     public cxxFlags : string [] = [];
+    /**
+     * Objective-C compiler flags parsed from this `compile_commands` entry.
+     * @description None parsed as of this writing.
+     */
     public objcFlags : string [] = [];
 
+    /**
+     * Parse `compile_commands` entry and store information in own fields.
+     * 
+     * @description This constructor expects all the fields produced by CMake
+     * to be present and of the correct type.
+     * 
+     * @param {any} cmakeJsonObj JavaScript object constructed after parsing
+     *        `compile_commands` entry.
+     * 
+     * @throws {Error} If any of the fields are missing or of the wrong type.
+     */
     constructor(
         cmakeJsonObj : any
     ) {

--- a/src/cpp_arg_parse.ts
+++ b/src/cpp_arg_parse.ts
@@ -1,10 +1,42 @@
 'use strict';
 
+/**
+ * Data container for identified preprocessor flags.
+ * 
+ * @description As of this writing, the only flags that will be stored on
+ * instances that implement this interface are:
+ * - Standard include path entries. Note that this does not include directories
+ *   added to the SYSTEM include path with `-isystem`.
+ * - Macro definitions. Note that this code does not attempt to evaluate any
+ *   shell expansions, such as those enclosed in `$()`.
+ * 
+ * @author Rolando J. Nieves
+ */
 export interface CppArgInfo {
+    /**
+     * List of standard include patch entries.
+     */
     includePath : string[];
+    /**
+     * List of macro definitions.
+     */
     macroDefines : string[];
 };
 
+/**
+ * Create `CppArgInfo` instance using information from compilation command line.
+ * 
+ * @description As of this writing, the only flags that will be detected by
+ * this function are:
+ * - `-I<arg>`: Addition to standard include path. Only the form that manifests
+ *   as a single command line argument is supported. Although `-I <arg>` is
+ *   legal, this function does not support it as of this writing.
+ * - `-D<arg>`: Addition to list of preprocessor macros.
+ * 
+ * @param {string} commandLine Compile command to parse.
+ * 
+ * @author Rolando J. Nieves
+ */
 export function cppArgParse(commandLine : string) : CppArgInfo {
     let result = {
         includePath: [],
@@ -17,11 +49,13 @@ export function cppArgParse(commandLine : string) : CppArgInfo {
         (aCmdArg : string) : void => {
             if (aCmdArg.startsWith("-I")) {
                 let candidateDir : string = aCmdArg.substr(2).trim();
+                // We only add an entry if it actually has any content.
                 if (candidateDir.length) {
                     result.includePath.push(candidateDir);
                 }
             } else if (aCmdArg.startsWith("-D")) {
                 let candidateDef : string = aCmdArg.substr(2).trim();
+                // We only add an entry if it actually has any content.
                 if (candidateDef.length) {
                     result.macroDefines.push(candidateDef);
                 }

--- a/src/cpp_arg_parse.ts
+++ b/src/cpp_arg_parse.ts
@@ -1,0 +1,33 @@
+'use strict';
+
+export interface CppArgInfo {
+    includePath : string[];
+    macroDefines : string[];
+};
+
+export function cppArgParse(commandLine : string) : CppArgInfo {
+    let result = {
+        includePath: [],
+        macroDefines: []
+    };
+    let anIncludePath : string = null;
+    let aMacroDef : string = null;
+
+    commandLine.split(" ").forEach(
+        (aCmdArg : string) : void => {
+            if (aCmdArg.startsWith("-I")) {
+                let candidateDir : string = aCmdArg.substr(2).trim();
+                if (candidateDir.length) {
+                    result.includePath.push(candidateDir);
+                }
+            } else if (aCmdArg.startsWith("-D")) {
+                let candidateDef : string = aCmdArg.substr(2).trim();
+                if (candidateDef.length) {
+                    result.macroDefines.push(candidateDef);
+                }
+            }
+        }
+    );
+
+    return result;
+}

--- a/src/cxx_arg_parse.ts
+++ b/src/cxx_arg_parse.ts
@@ -1,7 +1,12 @@
 'use strict';
 
-// These were acquired from the LLVM CLang Github repository at:
-// clang/include/clang/Frontend/LangStandards.def
+/**
+ * Known C++ language standards supported by CLang
+ * 
+ * @description These were acquired from the LLVM CLang Github repository at:
+ * - `clang/include/clang/Frontend/LangStandards.def`
+ * Accurate as of 2018-05-04
+ */
 const KNOWN_CXX_LANG_STDS : string[] = [
     "c++98",
     "c++03",
@@ -23,13 +28,58 @@ const KNOWN_CXX_LANG_STDS : string[] = [
     "gnu++2a"
 ];
 
+/**
+ * Data container for identified C++ compiler flags.
+ * 
+ * @description As of this writing, the only flags that will be stored on
+ * instances that implement this interface are:
+ * - C++ Language standard (from the menu of known supported standards to date)
+ * - Cross compilation system root directory
+ * - Cross compilation "target triple" identifier.
+ * - C++ Standard Library to use
+ * 
+ * @author Rolando J. Nieves
+ */
 export interface CxxArgInfo {
+    /**
+     * C++ language standard detected in compile command line.
+     */
     langStandard : string;
+    /**
+     * Cross compilation system root directory detected in compile command line.
+     */
     systemRoot : string;
+    /**
+     * Cross compilation "target triple" identified detected in compile command line.
+     * 
+     * @description This field will only be populated if the project using this
+     * extension is actually built using CLang.
+     */
     crossTarget : string;
+    /**
+     * C++ standard library detected in compile command line.
+     * 
+     * @description This field will only be populated if the project using this
+     * extension is actually built using CLang.
+     */
     cxxStdLibrary : string;
 }
 
+/**
+ * Create `CxxArgInfo` instance using information from compilation command line
+ * 
+ * @description As of this writing, the only flags that will be detected by
+ * this function are:
+ * - `-std=<arg>`: C++ language standard. `<arg>` must identify a standard
+ *   supported by CLang as of this writing.
+ * - `--sysroot=<arg>`: Cross compilation system root directory. `<arg>` is
+ *   taken as-is.
+ * - `-target <arg>`: Cross compilation "target triple." Also detected as
+ *   `--target=<arg>`. `<arg>` is taken as-is.
+ * - `-stdlib=<arg>`: C++ standard library. `<arg>` is taken as-is.
+ * 
+ * @param {string} commandLine Compile command to parse.
+ */
 export function cxxArgParse(commandLine : string) : CxxArgInfo {
     let result = {
         langStandard: null,
@@ -47,16 +97,24 @@ export function cxxArgParse(commandLine : string) : CxxArgInfo {
                 targetIncoming = false;
             } else if (aCmdArg.startsWith("-std=")) {
                 stdCandidate = aCmdArg.substr(5);
+                // We will only accept C language standards supported by CLang
+                // as of this writing.
                 if (KNOWN_CXX_LANG_STDS.indexOf(stdCandidate) != -1) {
                     result.langStandard = stdCandidate;
                 }
             } else if (aCmdArg.startsWith("--sysroot=")) {
                 result.systemRoot = aCmdArg.substr(10);
             } else if (aCmdArg == "-target") {
+                // Variation of target triple option split into two arguments.
+                // Next iteration will pick up the actual value. The only
+                // protection that exists against an improperly constructed
+                // compile command that is missing the actual value is that
+                // the function will not cause a runtime error.
                 targetIncoming = true;
             } else if (aCmdArg.startsWith("-stdlib=")) {
                 result.cxxStdLibrary = aCmdArg.substr(8);
             } else if (aCmdArg.startsWith("--target=")) {
+                // Variation of target triple that is all in one argument.
                 result.crossTarget = aCmdArg.substr(9);
             }
         }

--- a/src/cxx_arg_parse.ts
+++ b/src/cxx_arg_parse.ts
@@ -79,6 +79,8 @@ export interface CxxArgInfo {
  * - `-stdlib=<arg>`: C++ standard library. `<arg>` is taken as-is.
  * 
  * @param {string} commandLine Compile command to parse.
+ * 
+ * @author Rolando J. Nieves
  */
 export function cxxArgParse(commandLine : string) : CxxArgInfo {
     let result = {

--- a/src/cxx_arg_parse.ts
+++ b/src/cxx_arg_parse.ts
@@ -1,0 +1,66 @@
+'use strict';
+
+// These were acquired from the LLVM CLang Github repository at:
+// clang/include/clang/Frontend/LangStandards.def
+const KNOWN_CXX_LANG_STDS : string[] = [
+    "c++98",
+    "c++03",
+    "gnu++98",
+    "gnu++03",
+    "c++11",
+    "c++0x",
+    "gnu++11",
+    "gnu++0x",
+    "c++14",
+    "c++1y",
+    "gnu++14",
+    "gnu++1y",
+    "c++17",
+    "c++1z",
+    "gnu++17",
+    "gnu++1z",
+    "c++2a",
+    "gnu++2a"
+];
+
+export interface CxxArgInfo {
+    langStandard : string;
+    systemRoot : string;
+    crossTarget : string;
+    cxxStdLibrary : string;
+}
+
+export function cxxArgParse(commandLine : string) : CxxArgInfo {
+    let result = {
+        langStandard: null,
+        systemRoot: null,
+        crossTarget: null,
+        cxxStdLibrary: null
+    }
+    let stdCandidate : string = null;
+    let targetIncoming : boolean = false;
+
+    commandLine.split(" ").forEach(
+        (aCmdArg : string) : void => {
+            if (targetIncoming) {
+                result.crossTarget = aCmdArg.trim();
+                targetIncoming = false;
+            } else if (aCmdArg.startsWith("-std=")) {
+                stdCandidate = aCmdArg.substr(5);
+                if (KNOWN_CXX_LANG_STDS.indexOf(stdCandidate) != -1) {
+                    result.langStandard = stdCandidate;
+                }
+            } else if (aCmdArg.startsWith("--sysroot=")) {
+                result.systemRoot = aCmdArg.substr(10);
+            } else if (aCmdArg == "-target") {
+                targetIncoming = true;
+            } else if (aCmdArg.startsWith("-stdlib=")) {
+                result.cxxStdLibrary = aCmdArg.substr(8);
+            } else if (aCmdArg.startsWith("--target=")) {
+                result.crossTarget = aCmdArg.substr(9);
+            }
+        }
+    );
+
+    return result;
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -27,7 +27,7 @@ export function activate(context: vscode.ExtensionContext) {
 	let disposable = vscode.commands.registerCommand(
 		"cmake.update_clang_flags",
 		() => {
-			clangCppFlagsUpdater.updateClangCppFlags();
+			clangCppFlagsUpdater.updateClangCompilerFlags();
 		}
 	);
 

--- a/src/test/c_arg_parse.test.ts
+++ b/src/test/c_arg_parse.test.ts
@@ -1,0 +1,141 @@
+import * as assert from 'assert';
+
+import { CArgInfo, cArgParse } from '../c_arg_parse';
+
+suite("C Compiler Argument Parsing Tests", () => {
+    test("Simple with Nothing Harvested", () => {
+        let compilerCommandString : string = "gcc -g -O2 -I. -I../src -c -o somefile.o somefile.c";
+        let parseResult : CArgInfo = cArgParse(compilerCommandString);
+        assert.equal(parseResult.langStandard, null, "C language standard");
+        assert.equal(parseResult.systemRoot, null, "C cross compilation system root");
+        assert.equal(parseResult.crossTarget, null, "C cross compilation target triple");
+    });
+
+    test("Success with Valid Language Standard Harvested", () => {
+        let compilerCommandString : string = "gcc -g -O2 -I. -I../src -std=gnu11 -c -o somefile.o somefile.c";
+        let parseResult : CArgInfo = cArgParse(compilerCommandString);
+        assert.equal(parseResult.langStandard, "gnu11", "C language standard");
+        assert.equal(parseResult.systemRoot, null, "C cross compilation system root");
+        assert.equal(parseResult.crossTarget, null, "C cross compilation target triple");
+    });
+
+    test("Tolerate Invalid Language Standard Value", () => {
+        let compilerCommandString : string = "gcc -g -O2 -I. -I../src -std=bogus -c -o somefile.o somefile.c";
+        let parseResult : CArgInfo = cArgParse(compilerCommandString);
+        assert.equal(parseResult.langStandard, null, "C language standard");
+        assert.equal(parseResult.systemRoot, null, "C cross compilation system root");
+        assert.equal(parseResult.crossTarget, null, "C cross compilation target triple");
+    });
+
+    test("Tolerate Invalid Language Standard Flag", () => {
+        let compilerCommandString : string = "gcc -g -O2 -I. -I../src --std=gnu11 -c -o somefile.o somefile.c";
+        let parseResult : CArgInfo = cArgParse(compilerCommandString);
+        assert.equal(parseResult.langStandard, null, "C language standard");
+        assert.equal(parseResult.systemRoot, null, "C cross compilation system root");
+        assert.equal(parseResult.crossTarget, null, "C cross compilation target triple");
+    });
+
+    test("Success with Valid System Root Harvested", () => {
+        let compilerCommandString : string = "gcc -g -O2 -I. -I../src --sysroot=/opt/yocto/sysroots/armv7-none-linux-gnueabi -c -o somefile.o somefile.c";
+        let parseResult : CArgInfo = cArgParse(compilerCommandString);
+        assert.equal(parseResult.langStandard, null, "C language standard");
+        assert.equal(parseResult.systemRoot, "/opt/yocto/sysroots/armv7-none-linux-gnueabi", "C cross compilation system root");
+        assert.equal(parseResult.crossTarget, null, "C cross compilation target triple");
+    });
+
+    test("Tolerate Invalid System Root Flag", () => {
+        let compilerCommandString : string = "gcc -g -O2 -I. -I../src -sysroot /opt/yocto/sysroots/armv7-none-linux-gnueabi -c -o somefile.o somefile.c";
+        let parseResult : CArgInfo = cArgParse(compilerCommandString);
+        assert.equal(parseResult.langStandard, null, "C language standard");
+        assert.equal(parseResult.systemRoot, null, "C cross compilation system root");
+        assert.equal(parseResult.crossTarget, null, "C cross compilation target triple");
+    });
+
+    test("Success with Valid Target Triple Harvested Op. 1 (CLang)", () => {
+        let compilerCommandString : string = "clang -g -O2 -I. -I../src -target armv7-none-linux-gnueabi -c -o somefile.o somefile.c";
+        let parseResult : CArgInfo = cArgParse(compilerCommandString);
+        assert.equal(parseResult.langStandard, null, "C language standard");
+        assert.equal(parseResult.systemRoot, null, "C cross compilation system root");
+        assert.equal(parseResult.crossTarget, "armv7-none-linux-gnueabi", "C cross compilation target triple");
+    });
+
+    test("Success with Valid Target Triple Harvested Op. 2 (CLang)", () => {
+        let compilerCommandString : string = "clang -g -O2 -I. -I../src --target=armv7-none-linux-gnueabi -c -o somefile.o somefile.c";
+        let parseResult : CArgInfo = cArgParse(compilerCommandString);
+        assert.equal(parseResult.langStandard, null, "C language standard");
+        assert.equal(parseResult.systemRoot, null, "C cross compilation system root");
+        assert.equal(parseResult.crossTarget, "armv7-none-linux-gnueabi", "C cross compilation target triple");
+    });
+
+    test("Tolerate Invalid Target Triple Flag Op. 2 (CLang)", () => {
+        let compilerCommandString : string = "clang -g -O2 -I. -I../src --target armv7-none-linux-gnueabi -c -o somefile.o somefile.c";
+        let parseResult : CArgInfo = cArgParse(compilerCommandString);
+        assert.equal(parseResult.langStandard, null, "C language standard");
+        assert.equal(parseResult.systemRoot, null, "C cross compilation system root");
+        assert.equal(parseResult.crossTarget, null, "C cross compilation target triple");
+    });
+
+    test("Failed Parse with Missing Target Triple (CLang)", () => {
+        let compilerCommandString : string = "clang -g -O2 -I. -I../src -target -c -o somefile.o somefile.c";
+        let parseResult : CArgInfo = cArgParse(compilerCommandString);
+        assert.equal(parseResult.langStandard, null, "C language standard");
+        assert.equal(parseResult.systemRoot, null, "C cross compilation system root");
+        assert.equal(parseResult.crossTarget, "-c", "C cross compilation target triple");
+    });
+
+    test("Tolerate Invalid Target Triple Flag Op. 1 (CLang)", () => {
+        let compilerCommandString : string = "clang -g -O2 -I. -I../src -target=armv7-none-linux-gnueabi -c -o somefile.o somefile.c";
+        let parseResult : CArgInfo = cArgParse(compilerCommandString);
+        assert.equal(parseResult.langStandard, null, "C language standard");
+        assert.equal(parseResult.systemRoot, null, "C cross compilation system root");
+        assert.equal(parseResult.crossTarget, null, "C cross compilation target triple");
+    });
+
+    test("Typical Cross Compilation Line (GCC)", () => {
+        let compilerCommandString : string = "armv7-none-linux-gnueabi-gcc -g -O2 -I. -I../src --sysroot=/opt/yocto/sysroots/armv7-none-linux-gnueabi -c -o somefile.o somefile.c";
+        let parseResult : CArgInfo = cArgParse(compilerCommandString);
+        assert.equal(parseResult.langStandard, null, "C language standard");
+        assert.equal(parseResult.systemRoot, "/opt/yocto/sysroots/armv7-none-linux-gnueabi", "C cross compilation system root");
+        assert.equal(parseResult.crossTarget, null, "C cross compilation target triple");
+    });
+
+    test("Typical Cross Compilation Line (CLang)", () => {
+        let compilerCommandString : string = "clang -g -O2 -I. -I../src -target armv7-none-linux-gnueabi --sysroot=/opt/yocto/sysroots/armv7-none-linux-gnueabi -c -o somefile.o somefile.c";
+        let parseResult : CArgInfo = cArgParse(compilerCommandString);
+        assert.equal(parseResult.langStandard, null, "C language standard");
+        assert.equal(parseResult.systemRoot, "/opt/yocto/sysroots/armv7-none-linux-gnueabi", "C cross compilation system root");
+        assert.equal(parseResult.crossTarget, "armv7-none-linux-gnueabi", "C cross compilation target triple");
+    });
+
+    test("Typical Cross Compilation Line (GCC)", () => {
+        let compilerCommandString : string = "armv7-none-linux-gnueabi-gcc -g -O2 -I. -I../src --sysroot=/opt/yocto/sysroots/armv7-none-linux-gnueabi -c -o somefile.o somefile.c";
+        let parseResult : CArgInfo = cArgParse(compilerCommandString);
+        assert.equal(parseResult.langStandard, null, "C language standard");
+        assert.equal(parseResult.systemRoot, "/opt/yocto/sysroots/armv7-none-linux-gnueabi", "C cross compilation system root");
+        assert.equal(parseResult.crossTarget, null, "C cross compilation target triple");
+    });
+
+    test("Typical Cross Compilation Line (CLang)", () => {
+        let compilerCommandString : string = "clang -g -O2 -I. -I../src -target armv7-none-linux-gnueabi --sysroot=/opt/yocto/sysroots/armv7-none-linux-gnueabi -c -o somefile.o somefile.c";
+        let parseResult : CArgInfo = cArgParse(compilerCommandString);
+        assert.equal(parseResult.langStandard, null, "C language standard");
+        assert.equal(parseResult.systemRoot, "/opt/yocto/sysroots/armv7-none-linux-gnueabi", "C cross compilation system root");
+        assert.equal(parseResult.crossTarget, "armv7-none-linux-gnueabi", "C cross compilation target triple");
+    });
+
+    test("Maximum Harvest (GCC)", () => {
+        let compilerCommandString : string = "armv7-none-linux-gnueabi-gcc -g -O2 -I. -I../src -std=c17 --sysroot=/opt/yocto/sysroots/armv7-none-linux-gnueabi -c -o somefile.o somefile.c";
+        let parseResult : CArgInfo = cArgParse(compilerCommandString);
+        assert.equal(parseResult.langStandard, "c17", "C language standard");
+        assert.equal(parseResult.systemRoot, "/opt/yocto/sysroots/armv7-none-linux-gnueabi", "C cross compilation system root");
+        assert.equal(parseResult.crossTarget, null, "C cross compilation target triple");
+    });
+
+    test("Maximum Harvest (CLang)", () => {
+        let compilerCommandString : string = "clang -g -O2 -I. -I../src -target armv7-none-linux-gnueabi -std=c17 --sysroot=/opt/yocto/sysroots/armv7-none-linux-gnueabi -c -o somefile.o somefile.c";
+        let parseResult : CArgInfo = cArgParse(compilerCommandString);
+        assert.equal(parseResult.langStandard, "c17", "C language standard");
+        assert.equal(parseResult.systemRoot, "/opt/yocto/sysroots/armv7-none-linux-gnueabi", "C cross compilation system root");
+        assert.equal(parseResult.crossTarget, "armv7-none-linux-gnueabi", "C cross compilation target triple");
+    });
+});

--- a/src/test/c_arg_parse.test.ts
+++ b/src/test/c_arg_parse.test.ts
@@ -2,6 +2,11 @@ import * as assert from 'assert';
 
 import { CArgInfo, cArgParse } from '../c_arg_parse';
 
+/**
+ * Test suite for the `cArgParse()` function.
+ * 
+ * @author Rolando J. Nieves
+ */
 suite("C Compiler Argument Parsing Tests", () => {
     test("Simple with Nothing Harvested", () => {
         let compilerCommandString : string = "gcc -g -O2 -I. -I../src -c -o somefile.o somefile.c";

--- a/src/test/cmakecompilecmd.test.ts
+++ b/src/test/cmakecompilecmd.test.ts
@@ -1,0 +1,345 @@
+import * as assert from 'assert';
+
+import { CmakeCompileCmd } from '../cmakecompilecmd';
+
+/**
+ * Test suite for the `CmakeCompileCmd` class.
+ * @author Rolando J. Nieves
+ */
+suite("CmakeCompileCmd Class", () => {
+    test("Valid Entry Just Language Harvested (C)", () => {
+        let cmakeCompileCmd = {
+            directory: "/home/me/Documents/Projects/MyProject/build",
+            command: "gcc -g -O2 -c -o main.o main.c",
+            file: "/home/me/Documents/Projects/MyProject/src/main.c"
+        };
+
+        let unitUnderTest : CmakeCompileCmd = new CmakeCompileCmd(cmakeCompileCmd);
+        assert.equal(unitUnderTest.cFlags.length, 0, "C compiler flag count");
+        assert.equal(unitUnderTest.cppFlags.length, 0, "Preprocessor flag count");
+        assert.equal(unitUnderTest.cxxFlags.length, 0, "C++ compiler flag count");
+        assert.equal(unitUnderTest.objcFlags.length, 0, "Objective-C compiler flag count");
+        assert.strictEqual(unitUnderTest.language, CmakeCompileCmd.LANG_C, "Source file language");
+    });
+
+    test("Valid Entry Just Language Harvested (C++)", () => {
+        let cmakeCompileCmd = {
+            directory: "/home/me/Documents/Projects/MyProject/build",
+            command: "g++ -g -O2 -c -o main.o main.cpp",
+            file: "/home/me/Documents/Projects/MyProject/src/main.cpp"
+        };
+
+        let unitUnderTest : CmakeCompileCmd = new CmakeCompileCmd(cmakeCompileCmd);
+        assert.equal(unitUnderTest.cFlags.length, 0, "C compiler flag count");
+        assert.equal(unitUnderTest.cppFlags.length, 0, "Preprocessor flag count");
+        assert.equal(unitUnderTest.cxxFlags.length, 0, "C++ compiler flag count");
+        assert.equal(unitUnderTest.objcFlags.length, 0, "Objective-C compiler flag count");
+        assert.strictEqual(unitUnderTest.language, CmakeCompileCmd.LANG_CXX, "Source file language");
+    });
+
+    test("Valid Entry Just Language Harvested (Objective-C)", () => {
+        let cmakeCompileCmd = {
+            directory: "/home/me/Documents/Projects/MyProject/build",
+            command: "gcc -g -O2 -c -o main.o main.m",
+            file: "/home/me/Documents/Projects/MyProject/src/main.m"
+        };
+
+        let unitUnderTest : CmakeCompileCmd = new CmakeCompileCmd(cmakeCompileCmd);
+        assert.equal(unitUnderTest.cFlags.length, 0, "C compiler flag count");
+        assert.equal(unitUnderTest.cppFlags.length, 0, "Preprocessor flag count");
+        assert.equal(unitUnderTest.cxxFlags.length, 0, "C++ compiler flag count");
+        assert.equal(unitUnderTest.objcFlags.length, 0, "Objective-C compiler flag count");
+        assert.strictEqual(unitUnderTest.language, CmakeCompileCmd.LANG_OBJC, "Source file language");
+    });
+
+    test("Weird but Valid Entry Nothing Harvested", () => {
+        let cmakeCompileCmd = {
+            directory: "/home/me/Documents/Projects/MyProject/build",
+            command: "gcc -x c -g -O2 -c -o main.o main.what",
+            file: "/home/me/Documents/Projects/MyProject/src/main.what"
+        };
+
+        let unitUnderTest : CmakeCompileCmd = new CmakeCompileCmd(cmakeCompileCmd);
+        assert.equal(unitUnderTest.cFlags.length, 0, "C compiler flag count");
+        assert.equal(unitUnderTest.cppFlags.length, 0, "Preprocessor flag count");
+        assert.equal(unitUnderTest.cxxFlags.length, 0, "C++ compiler flag count");
+        assert.equal(unitUnderTest.objcFlags.length, 0, "Objective-C compiler flag count");
+        assert.strictEqual(unitUnderTest.language, null, "Source file language");
+    });
+
+    test("Invalid Entry Directory Missing", () => {
+        let cmakeCompileCmd = {
+            command: "gcc -g -O2 -c -o main.o main.c",
+            file: "/home/me/Documents/Projects/MyProject/src/main.c"
+        };
+
+        assert.throws(() => {
+            let unitUnderTest : CmakeCompileCmd = new CmakeCompileCmd(cmakeCompileCmd);
+        }, (err : any) : boolean => {
+            return (err instanceof Error) && (err.toString() == "Error: CMake compile command must contain string 'directory' field.");
+        }, "Missing directory field.");
+    });
+
+    test("Invalid Entry Directory Wrong Type", () => {
+        let cmakeCompileCmd = {
+            directory: 0,
+            command: "gcc -g -O2 -c -o main.o main.c",
+            file: "/home/me/Documents/Projects/MyProject/src/main.c"
+        };
+
+        assert.throws(() => {
+            let unitUnderTest : CmakeCompileCmd = new CmakeCompileCmd(cmakeCompileCmd);
+        }, (err : any) : boolean => {
+            return (err instanceof Error) && (err.toString() == "Error: CMake compile command must contain string 'directory' field.");
+        }, "Invalid directory field.");
+    });
+
+    test("Invalid Entry Command Missing", () => {
+        let cmakeCompileCmd = {
+            directory: "/home/me/Documents/Projects/MyProject/build",
+            file: "/home/me/Documents/Projects/MyProject/src/main.c"
+        };
+
+        assert.throws(() => {
+            let unitUnderTest : CmakeCompileCmd = new CmakeCompileCmd(cmakeCompileCmd);
+        }, (err : any) : boolean => {
+            return (err instanceof Error) && (err.toString() == "Error: CMake compile command must contain string 'command' field.");
+        }, "Missing command field.");
+    });
+
+    test("Invalid Entry Command Wrong Type", () => {
+        let cmakeCompileCmd = {
+            directory: "/home/me/Documents/Projects/MyProject/build",
+            command: 0,
+            file: "/home/me/Documents/Projects/MyProject/src/main.c"
+        };
+
+        assert.throws(() => {
+            let unitUnderTest : CmakeCompileCmd = new CmakeCompileCmd(cmakeCompileCmd);
+        }, (err : any) : boolean => {
+            return (err instanceof Error) && (err.toString() == "Error: CMake compile command must contain string 'command' field.");
+        }, "Invalid command field.");
+    });
+
+    test("Invalid Entry File Missing", () => {
+        let cmakeCompileCmd = {
+            directory: "/home/me/Documents/Projects/MyProject/build",
+            command: "gcc -g -O2 -c -o main.o main.c"
+        };
+
+        assert.throws(() => {
+            let unitUnderTest : CmakeCompileCmd = new CmakeCompileCmd(cmakeCompileCmd);
+        }, (err : any) : boolean => {
+            return (err instanceof Error) && (err.toString() == "Error: CMake compile command must contain string 'file' field.");
+        }, "Missing file field.");
+    });
+
+    test("Invalid Entry File Wrong Type", () => {
+        let cmakeCompileCmd = {
+            directory: "/home/me/Documents/Projects/MyProject/build",
+            command: "gcc -g -O2 -c -o main.o main.c",
+            file: 0
+        };
+
+        assert.throws(() => {
+            let unitUnderTest : CmakeCompileCmd = new CmakeCompileCmd(cmakeCompileCmd);
+        }, (err : any) : boolean => {
+            return (err instanceof Error) && (err.toString() == "Error: CMake compile command must contain string 'file' field.");
+        }, "Invalid file field.");
+    });
+
+    test("Typical Native Compile Harvest (GCC, C)", () => {
+        let cmakeCompileCmd = {
+            directory: "/home/me/Documents/Projects/MyProject/build",
+            command: "gcc -D_DEBUG -D_POSIX_C_SOURCE=200112L -I. -I../src -I/opt/coredx/target/include -std=gnu11 -g -O2 -c -o main.o main.c",
+            file: "/home/me/Documents/Projects/MyProject/src/main.c"
+        };
+
+        let unitUnderTest : CmakeCompileCmd = new CmakeCompileCmd(cmakeCompileCmd);
+        assert.equal(unitUnderTest.cFlags.length, 1, "C compiler flag count");
+        assert.equal(unitUnderTest.cFlags[0], "-std=gnu11", "C compiler language standard.");
+        assert.equal(unitUnderTest.cppFlags.length, 5, "Preprocessor flag count");
+        [
+            "-D_DEBUG",
+            "-D_POSIX_C_SOURCE=200112L",
+            "-I/home/me/Documents/Projects/MyProject/build",
+            "-I/home/me/Documents/Projects/MyProject/src",
+            "-I/opt/coredx/target/include"
+        ].forEach((aCppArg : string, index : number) => {
+            assert.equal(unitUnderTest.cppFlags[index], aCppArg, "Preprocessor argument '" + aCppArg + "'");
+        });
+        assert.equal(unitUnderTest.cxxFlags.length, 0, "C++ compiler flag count");
+        assert.equal(unitUnderTest.objcFlags.length, 0, "Objective-C compiler flag count");
+        assert.strictEqual(unitUnderTest.language, CmakeCompileCmd.LANG_C, "Source file language");
+    });
+
+    test("Typical Cross Compile Harvest (GCC, C)", () => {
+        let cmakeCompileCmd = {
+            directory: "/home/me/Documents/Projects/MyProject/build",
+            command: "armv7-none-linux-gnueabi-gcc -D_DEBUG -D_POSIX_C_SOURCE=200112L --sysroot=/opt/yocto/sysroots/armv7-none-linux-gnueabi -I. -I../src -I/opt/coredx/target/include -std=gnu11 -g -O2 -c -o main.o main.c",
+            file: "/home/me/Documents/Projects/MyProject/src/main.c"
+        };
+
+        let unitUnderTest : CmakeCompileCmd = new CmakeCompileCmd(cmakeCompileCmd);
+        assert.equal(unitUnderTest.cFlags.length, 2, "C compiler flag count");
+        [
+            "-std=gnu11",
+            "--sysroot=/opt/yocto/sysroots/armv7-none-linux-gnueabi",
+        ].forEach((aCFlag : string, index : number) => {
+            assert.equal(unitUnderTest.cFlags[index], aCFlag, "C Compiler flag '" + aCFlag + "'");
+        });
+        assert.equal(unitUnderTest.cppFlags.length, 5, "Preprocessor flag count");
+        [
+            "-D_DEBUG",
+            "-D_POSIX_C_SOURCE=200112L",
+            "-I/home/me/Documents/Projects/MyProject/build",
+            "-I/home/me/Documents/Projects/MyProject/src",
+            "-I/opt/coredx/target/include"
+        ].forEach((aCppArg : string, index : number) => {
+            assert.equal(unitUnderTest.cppFlags[index], aCppArg, "Preprocessor argument '" + aCppArg + "'");
+        });
+        assert.equal(unitUnderTest.cxxFlags.length, 1, "C++ compiler flag count");
+        assert.equal(unitUnderTest.cxxFlags[0], "--sysroot=/opt/yocto/sysroots/armv7-none-linux-gnueabi");
+        assert.equal(unitUnderTest.objcFlags.length, 0, "Objective-C compiler flag count");
+        assert.strictEqual(unitUnderTest.language, CmakeCompileCmd.LANG_C, "Source file language");
+    });
+
+    test("Typical Cross Compile Harvest (CLang, C)", () => {
+        let cmakeCompileCmd = {
+            directory: "/home/me/Documents/Projects/MyProject/build",
+            command: "clang -D_DEBUG -D_POSIX_C_SOURCE=200112L -target armv7-none-linux-gnueabi --sysroot=/opt/yocto/sysroots/armv7-none-linux-gnueabi -I. -I../src -I/opt/coredx/target/include -std=c11 -g -O2 -c -o main.o main.c",
+            file: "/home/me/Documents/Projects/MyProject/src/main.c"
+        };
+
+        let unitUnderTest : CmakeCompileCmd = new CmakeCompileCmd(cmakeCompileCmd);
+        assert.equal(unitUnderTest.cFlags.length, 4, "C compiler flag count");
+        [
+            "-std=c11",
+            "--sysroot=/opt/yocto/sysroots/armv7-none-linux-gnueabi",
+            "-target",
+            "armv7-none-linux-gnueabi",
+        ].forEach((aCFlag : string, index : number) => {
+            assert.equal(unitUnderTest.cFlags[index], aCFlag, "C Compiler flag '" + aCFlag + "'");
+        });
+        assert.equal(unitUnderTest.cppFlags.length, 5, "Preprocessor flag count");
+        [
+            "-D_DEBUG",
+            "-D_POSIX_C_SOURCE=200112L",
+            "-I/home/me/Documents/Projects/MyProject/build",
+            "-I/home/me/Documents/Projects/MyProject/src",
+            "-I/opt/coredx/target/include"
+        ].forEach((aCppArg : string, index : number) => {
+            assert.equal(unitUnderTest.cppFlags[index], aCppArg, "Preprocessor argument '" + aCppArg + "'");
+        });
+        assert.equal(unitUnderTest.cxxFlags.length, 3, "C++ compiler flag count");
+        [
+            "--sysroot=/opt/yocto/sysroots/armv7-none-linux-gnueabi",
+            "-target",
+            "armv7-none-linux-gnueabi"
+        ].forEach((aCxxFlag : string, index : number) => {
+            assert.equal(unitUnderTest.cxxFlags[index], aCxxFlag, "C++ Compiler flag '" + aCxxFlag + "'");
+        });
+        assert.equal(unitUnderTest.objcFlags.length, 0, "Objective-C compiler flag count");
+        assert.strictEqual(unitUnderTest.language, CmakeCompileCmd.LANG_C, "Source file language");
+    });
+
+    test("Typical Native Compile Harvest (GCC, C++)", () => {
+        let cmakeCompileCmd = {
+            directory: "/home/me/Documents/Projects/MyProject/build",
+            command: "g++ -D_DEBUG -D_POSIX_C_SOURCE=200112L -I. -I../src -I/opt/coredx/target/include -std=gnu++11 -g -O2 -c -o main.o main.cpp",
+            file: "/home/me/Documents/Projects/MyProject/src/main.cpp"
+        };
+
+        let unitUnderTest : CmakeCompileCmd = new CmakeCompileCmd(cmakeCompileCmd);
+        assert.equal(unitUnderTest.cFlags.length, 0, "C compiler flag count");
+        assert.equal(unitUnderTest.cppFlags.length, 5, "Preprocessor flag count");
+        [
+            "-D_DEBUG",
+            "-D_POSIX_C_SOURCE=200112L",
+            "-I/home/me/Documents/Projects/MyProject/build",
+            "-I/home/me/Documents/Projects/MyProject/src",
+            "-I/opt/coredx/target/include"
+        ].forEach((aCppArg : string, index : number) => {
+            assert.equal(unitUnderTest.cppFlags[index], aCppArg, "Preprocessor argument '" + aCppArg + "'");
+        });
+        assert.equal(unitUnderTest.cxxFlags.length, 1, "C++ compiler flag count");
+        assert.equal(unitUnderTest.cxxFlags[0], "-std=gnu++11", "C++ Compiler flag '-std=gnu++11'");
+        assert.equal(unitUnderTest.objcFlags.length, 0, "Objective-C compiler flag count");
+        assert.strictEqual(unitUnderTest.language, CmakeCompileCmd.LANG_CXX, "Source file language");
+    });
+
+    test("Typical Cross Compile Harvest (GCC, C++)", () => {
+        let cmakeCompileCmd = {
+            directory: "/home/me/Documents/Projects/MyProject/build",
+            command: "armv7-none-linux-gnueabi-g++ -D_DEBUG -D_POSIX_C_SOURCE=200112L --sysroot=/opt/yocto/sysroots/armv7-none-linux-gnueabi -I. -I../src -I/opt/coredx/target/include -std=gnu++11 -g -O2 -c -o main.o main.cxx",
+            file: "/home/me/Documents/Projects/MyProject/src/main.cxx"
+        };
+
+        let unitUnderTest : CmakeCompileCmd = new CmakeCompileCmd(cmakeCompileCmd);
+        assert.equal(unitUnderTest.cFlags.length, 1, "C compiler flag count");
+        [
+            "--sysroot=/opt/yocto/sysroots/armv7-none-linux-gnueabi"
+        ].forEach((aCFlag : string, index : number) => {
+            assert.equal(unitUnderTest.cFlags[index], aCFlag, "C Compiler flag '" + aCFlag + "'");
+        });
+        assert.equal(unitUnderTest.cppFlags.length, 5, "Preprocessor flag count");
+        [
+            "-D_DEBUG",
+            "-D_POSIX_C_SOURCE=200112L",
+            "-I/home/me/Documents/Projects/MyProject/build",
+            "-I/home/me/Documents/Projects/MyProject/src",
+            "-I/opt/coredx/target/include"
+        ].forEach((aCppArg : string, index : number) => {
+            assert.equal(unitUnderTest.cppFlags[index], aCppArg, "Preprocessor argument '" + aCppArg + "'");
+        });
+        assert.equal(unitUnderTest.cxxFlags.length, 2, "C++ compiler flag count");
+        [
+            "-std=gnu++11",
+            "--sysroot=/opt/yocto/sysroots/armv7-none-linux-gnueabi"
+        ].forEach((aCxxFlag : string, index : number) => {
+            assert.equal(unitUnderTest.cxxFlags[index], aCxxFlag, "C++ Compiler flag '" + aCxxFlag + "'");
+        });
+        assert.equal(unitUnderTest.objcFlags.length, 0, "Objective-C compiler flag count");
+        assert.strictEqual(unitUnderTest.language, CmakeCompileCmd.LANG_CXX, "Source file language");
+    });
+
+    test("Typical Cross Compile Harvest (CLang, C++)", () => {
+        let cmakeCompileCmd = {
+            directory: "/home/me/Documents/Projects/MyProject/build",
+            command: "clang++ -D_DEBUG -D_POSIX_C_SOURCE=200112L -target armv7-none-linux-gnueabi --sysroot=/opt/yocto/sysroots/armv7-none-linux-gnueabi -I. -I../src -I/opt/coredx/target/include -std=c++11 -g -O2 -c -o main.o main.cc",
+            file: "/home/me/Documents/Projects/MyProject/src/main.cc"
+        };
+
+        let unitUnderTest : CmakeCompileCmd = new CmakeCompileCmd(cmakeCompileCmd);
+        assert.equal(unitUnderTest.cFlags.length, 3, "C compiler flag count");
+        [
+            "--sysroot=/opt/yocto/sysroots/armv7-none-linux-gnueabi",
+            "-target",
+            "armv7-none-linux-gnueabi"
+        ].forEach((aCFlag : string, index : number) => {
+            assert.equal(unitUnderTest.cFlags[index], aCFlag, "C Compiler flag '" + aCFlag + "'");
+        });
+        assert.equal(unitUnderTest.cFlags[0], "--sysroot=/opt/yocto/sysroots/armv7-none-linux-gnueabi");
+        assert.equal(unitUnderTest.cppFlags.length, 5, "Preprocessor flag count");
+        [
+            "-D_DEBUG",
+            "-D_POSIX_C_SOURCE=200112L",
+            "-I/home/me/Documents/Projects/MyProject/build",
+            "-I/home/me/Documents/Projects/MyProject/src",
+            "-I/opt/coredx/target/include"
+        ].forEach((aCppArg : string, index : number) => {
+            assert.equal(unitUnderTest.cppFlags[index], aCppArg, "Preprocessor argument '" + aCppArg + "'");
+        });
+        assert.equal(unitUnderTest.cxxFlags.length, 4, "C++ compiler flag count");
+        [
+            "-std=c++11",
+            "--sysroot=/opt/yocto/sysroots/armv7-none-linux-gnueabi",
+            "-target",
+            "armv7-none-linux-gnueabi"
+        ].forEach((aCxxFlag : string, index : number) => {
+            assert.equal(unitUnderTest.cxxFlags[index], aCxxFlag, "C++ Compiler flag '" + aCxxFlag + "'");
+        });
+        assert.equal(unitUnderTest.objcFlags.length, 0, "Objective-C compiler flag count");
+        assert.strictEqual(unitUnderTest.language, CmakeCompileCmd.LANG_CXX, "Source file language");
+    });
+});

--- a/src/test/cmakecompilecmd.test.ts
+++ b/src/test/cmakecompilecmd.test.ts
@@ -4,6 +4,7 @@ import { CmakeCompileCmd } from '../cmakecompilecmd';
 
 /**
  * Test suite for the `CmakeCompileCmd` class.
+ * 
  * @author Rolando J. Nieves
  */
 suite("CmakeCompileCmd Class", () => {

--- a/src/test/cpp_arg_parse.test.ts
+++ b/src/test/cpp_arg_parse.test.ts
@@ -2,6 +2,11 @@ import * as assert from 'assert';
 
 import { CppArgInfo, cppArgParse } from '../cpp_arg_parse';
 
+/**
+ * Test suite for the `cppArgParse()` function.
+ * 
+ * @author Rolando J. Nieves
+ */
 suite("Preprocessor Argument Parsing Tests", () => {
     test("Simple with Nothing Harvested", () => {
         let compilerCommandString : string = "gcc -g -O2 -c -o somefile.o somefile.c";

--- a/src/test/cpp_arg_parse.test.ts
+++ b/src/test/cpp_arg_parse.test.ts
@@ -1,0 +1,132 @@
+import * as assert from 'assert';
+
+import { CppArgInfo, cppArgParse } from '../cpp_arg_parse';
+
+suite("Preprocessor Argument Parsing Tests", () => {
+    test("Simple with Nothing Harvested", () => {
+        let compilerCommandString : string = "gcc -g -O2 -c -o somefile.o somefile.c";
+        let parseResult : CppArgInfo = cppArgParse(compilerCommandString);
+        assert.equal(parseResult.includePath.length, 0, "Preprocessor include path count");
+        assert.equal(parseResult.macroDefines.length, 0, "Preprocessor macro definitions count");
+    });
+
+    test("Success with Single Include Directory (Absolute)", () => {
+        let compilerCommandString : string = "gcc -g -O2 -I/opt/coredx/target/include -c -o somefile.o somefile.c";
+        let parseResult : CppArgInfo = cppArgParse(compilerCommandString);
+        assert.equal(parseResult.includePath.length, 1, "Preprocessor include path count");
+        [ "/opt/coredx/target/include" ].forEach((aPath : string, index: number) => {
+            assert.equal(parseResult.includePath[index], aPath, "A preprocessor include path '" + aPath + "'");
+        });
+        assert.equal(parseResult.macroDefines.length, 0, "Preprocessor macro definitions count");
+    });
+
+    test("Success with Single Include Directory (Relative)", () => {
+        let compilerCommandString : string = "gcc -g -O2 -I../src -c -o somefile.o somefile.c";
+        let parseResult : CppArgInfo = cppArgParse(compilerCommandString);
+        assert.equal(parseResult.includePath.length, 1, "Preprocessor include path count");
+        [ "../src" ].forEach((aPath : string, index: number) => {
+            assert.equal(parseResult.includePath[index], aPath, "A preprocessor include path '" + aPath + "'");
+        });
+        assert.equal(parseResult.macroDefines.length, 0, "Preprocessor macro definitions count");
+    });
+
+    test("Failed Parse with Alternative Valid Syntax", () => {
+        let compilerCommandString : string = "gcc -g -O2 -I . -c -o somefile.o somefile.c";
+        let parseResult : CppArgInfo = cppArgParse(compilerCommandString);
+        assert.equal(parseResult.includePath.length, 0, "Preprocessor include path count");
+        assert.equal(parseResult.macroDefines.length, 0, "Preprocessor macro definitions count");
+    });
+
+    test("Success with Multiple Include Directories (Absolute)", () => {
+        let compilerCommandString : string = "gcc -g -O2 -I/opt/coredx/target/include -I/opt/X11/include -c -o somefile.o somefile.c";
+        let parseResult : CppArgInfo = cppArgParse(compilerCommandString);
+        assert.equal(parseResult.includePath.length, 2, "Preprocessor include path count");
+        [ "/opt/coredx/target/include", "/opt/X11/include" ].forEach((aPath : string, index: number) => {
+            assert.equal(parseResult.includePath[index], aPath, "A preprocessor include path '" + aPath + "'");
+        });
+        assert.equal(parseResult.macroDefines.length, 0, "Preprocessor macro definitions count");
+    });
+
+    test("Success with Multiple Include Directories (Relative)", () => {
+        let compilerCommandString : string = "gcc -g -O2 -I../src -I. -c -o somefile.o somefile.c";
+        let parseResult : CppArgInfo = cppArgParse(compilerCommandString);
+        assert.equal(parseResult.includePath.length, 2, "Preprocessor include path count");
+        [ "../src", "." ].forEach((aPath : string, index: number) => {
+            assert.equal(parseResult.includePath[index], aPath, "A preprocessor path include '" + aPath + "'");
+        });
+        assert.equal(parseResult.macroDefines.length, 0, "Preprocessor macro definitions count");
+    });
+
+    test("Success with Multiple Include Directories (Mix)", () => {
+        let compilerCommandString : string = "gcc -g -O2 -I/opt/coredx/target/include -I/opt/X11/include -I. -I../src -c -o somefile.o somefile.c";
+        let parseResult : CppArgInfo = cppArgParse(compilerCommandString);
+        assert.equal(parseResult.includePath.length, 4, "Preprocessor include path count");
+        [ "/opt/coredx/target/include", "/opt/X11/include", ".", "../src" ].forEach((aPath : string, index : number) => {
+            assert.equal(parseResult.includePath[index], aPath, "A preprocessor include path '" + aPath + "'");
+        });
+        assert.equal(parseResult.macroDefines.length, 0, "Preprocessor macro definitions count");
+    });
+
+    test("Success with Single Macro Definition (Simple)", () => {
+        let compilerCommandString : string = "gcc -g -O2 -DMyProject_EXPORTS -c -o somefile.o somefile.c";
+        let parseResult : CppArgInfo = cppArgParse(compilerCommandString);
+        assert.equal(parseResult.includePath.length, 0, "Preprocessor include path count");
+        assert.equal(parseResult.macroDefines.length, 1, "Preprocessor macro definitions count");
+        [ "MyProject_EXPORTS" ].forEach((aMacroDef : string, index: number) => {
+            assert.equal(parseResult.macroDefines[index], aMacroDef, "A preprocessor macro definition '" + aMacroDef + "'");
+        });
+    });
+
+    test("Success with Multiple Macro Definitions (Simple)", () => {
+        let compilerCommandString : string = "gcc -g -O2 -DMyProject_EXPORTS -D_DEBUG -c -o somefile.o somefile.c";
+        let parseResult : CppArgInfo = cppArgParse(compilerCommandString);
+        assert.equal(parseResult.includePath.length, 0, "Preprocessor include path count");
+        assert.equal(parseResult.macroDefines.length, 2, "Preprocessor macro definitions count");
+        [ "MyProject_EXPORTS", "_DEBUG" ].forEach((aMacroDef : string, index: number) => {
+            assert.equal(parseResult.macroDefines[index], aMacroDef, "A preprocessor macro definition '" + aMacroDef + "'");
+        });
+    });
+
+    test("Success with Single Macro Definition (Assignment)", () => {
+        let compilerCommandString : string = "gcc -g -O2 -D_POSIX_C_SOURCE=200112L -c -o somefile.o somefile.c";
+        let parseResult : CppArgInfo = cppArgParse(compilerCommandString);
+        assert.equal(parseResult.includePath.length, 0, "Preprocessor include path count");
+        assert.equal(parseResult.macroDefines.length, 1, "Preprocessor macro definitions count");
+        [ "_POSIX_C_SOURCE=200112L" ].forEach((aMacroDef : string, index: number) => {
+            assert.equal(parseResult.macroDefines[index], aMacroDef, "A preprocessor macro definition '" + aMacroDef + "'");
+        });
+    });
+
+    test("Success with Multiple Macro Definitions (Assignment)", () => {
+        let compilerCommandString : string = "gcc -g -O2 -D_POSIX_C_SOURCE=200112L -DMYPROJECT_MAX_COUNT=20 -c -o somefile.o somefile.c";
+        let parseResult : CppArgInfo = cppArgParse(compilerCommandString);
+        assert.equal(parseResult.includePath.length, 0, "Preprocessor include path count");
+        assert.equal(parseResult.macroDefines.length, 2, "Preprocessor macro definitions count");
+        [ "_POSIX_C_SOURCE=200112L", "MYPROJECT_MAX_COUNT=20" ].forEach((aMacroDef : string, index: number) => {
+            assert.equal(parseResult.macroDefines[index], aMacroDef, "A preprocessor macro definition '" + aMacroDef + "'");
+        });
+    });
+
+    test("Success with Multiple Macro Definitions (Mix)", () => {
+        let compilerCommandString : string = "gcc -g -O2 -DMyProject_EXPORTS -D_DEBUG -D_POSIX_C_SOURCE=200112L -DMYPROJECT_MAX_COUNT=20 -c -o somefile.o somefile.c";
+        let parseResult : CppArgInfo = cppArgParse(compilerCommandString);
+        assert.equal(parseResult.includePath.length, 0, "Preprocessor include path count");
+        assert.equal(parseResult.macroDefines.length, 4, "Preprocessor macro definitions count");
+        [ "MyProject_EXPORTS", "_DEBUG", "_POSIX_C_SOURCE=200112L", "MYPROJECT_MAX_COUNT=20" ].forEach((aMacroDef : string, index: number) => {
+            assert.equal(parseResult.macroDefines[index], aMacroDef, "A preprocessor macro definition '" + aMacroDef + "'");
+        });
+    });
+
+    test("Maximum Harvest", () => {
+        let compilerCommandString : string = "gcc -g -O2 -DMyProject_EXPORTS -D_DEBUG -D_POSIX_C_SOURCE=200112L -DMYPROJECT_MAX_COUNT=20 -I/opt/coredx/target/include -I/opt/X11/include -I. -I../src -c -o somefile.o somefile.c";
+        let parseResult : CppArgInfo = cppArgParse(compilerCommandString);
+        assert.equal(parseResult.includePath.length, 4, "Preprocessor include path count");
+        [ "/opt/coredx/target/include", "/opt/X11/include", ".", "../src" ].forEach((aPath : string, index : number) => {
+            assert.equal(parseResult.includePath[index], aPath, "A preprocessor include path '" + aPath + "'");
+        });
+        assert.equal(parseResult.macroDefines.length, 4, "Preprocessor macro definitions count");
+        [ "MyProject_EXPORTS", "_DEBUG", "_POSIX_C_SOURCE=200112L", "MYPROJECT_MAX_COUNT=20" ].forEach((aMacroDef : string, index: number) => {
+            assert.equal(parseResult.macroDefines[index], aMacroDef, "A preprocessor macro definition '" + aMacroDef + "'");
+        });
+    });
+});

--- a/src/test/cxx_arg_parse.test.ts
+++ b/src/test/cxx_arg_parse.test.ts
@@ -1,0 +1,185 @@
+import * as assert from 'assert';
+
+import { CxxArgInfo, cxxArgParse } from '../cxx_arg_parse';
+
+suite("C++ Compiler Argument Parsing Tests", () => {
+    test("Simple with Nothing Harvested", () => {
+        let compilerCommandString : string = "g++ -g -O2 -I. -I../src -c -o somefile.o somefile.cpp";
+        let parseResult : CxxArgInfo = cxxArgParse(compilerCommandString);
+        assert.equal(parseResult.langStandard, null, "C++ language standard");
+        assert.equal(parseResult.systemRoot, null, "C++ cross compilation system root");
+        assert.equal(parseResult.crossTarget, null, "C++ cross compilation target triple");
+        assert.equal(parseResult.cxxStdLibrary, null, "C++ standard library");
+    });
+
+    test("Success with Valid Language Standard Harvested", () => {
+        let compilerCommandString : string = "g++ -g -O2 -I. -I../src -std=gnu++11 -c -o somefile.o somefile.cpp";
+        let parseResult : CxxArgInfo = cxxArgParse(compilerCommandString);
+        assert.equal(parseResult.langStandard, "gnu++11", "C++ language standard");
+        assert.equal(parseResult.systemRoot, null, "C++ cross compilation system root");
+        assert.equal(parseResult.crossTarget, null, "C++ cross compilation target triple");
+        assert.equal(parseResult.cxxStdLibrary, null, "C++ standard library");
+    });
+
+    test("Tolerate Invalid Language Standard Value", () => {
+        let compilerCommandString : string = "g++ -g -O2 -I. -I../src -std=bogus -c -o somefile.o somefile.cpp";
+        let parseResult : CxxArgInfo = cxxArgParse(compilerCommandString);
+        assert.equal(parseResult.langStandard, null, "C++ language standard");
+        assert.equal(parseResult.systemRoot, null, "C++ cross compilation system root");
+        assert.equal(parseResult.crossTarget, null, "C++ cross compilation target triple");
+        assert.equal(parseResult.cxxStdLibrary, null, "C++ standard library");
+    });
+
+    test("Tolerate Invalid Language Standard Flag", () => {
+        let compilerCommandString : string = "g++ -g -O2 -I. -I../src --std=gnu++11 -c -o somefile.o somefile.cpp";
+        let parseResult : CxxArgInfo = cxxArgParse(compilerCommandString);
+        assert.equal(parseResult.langStandard, null, "C++ language standard");
+        assert.equal(parseResult.systemRoot, null, "C++ cross compilation system root");
+        assert.equal(parseResult.crossTarget, null, "C++ cross compilation target triple");
+        assert.equal(parseResult.cxxStdLibrary, null, "C++ standard library");
+    });
+
+    test("Success with Valid C++ Standard Library Harvested (CLang)", () => {
+        let compilerCommandString : string = "clang++ -g -O2 -I. -I../src -std=gnu++11 -stdlib=libstdc++ -c -o somefile.o somefile.cpp";
+        let parseResult : CxxArgInfo = cxxArgParse(compilerCommandString);
+        assert.equal(parseResult.langStandard, "gnu++11", "C++ language standard");
+        assert.equal(parseResult.systemRoot, null, "C++ cross compilation system root");
+        assert.equal(parseResult.crossTarget, null, "C++ cross compilation target triple");
+        assert.equal(parseResult.cxxStdLibrary, "libstdc++", "C++ standard library");
+    });
+
+    test("Tolerate Invalid C++ Standard Library Flag Op. 1 (CLang)", () => {
+        let compilerCommandString : string = "clang++ -g -O2 -I. -I../src --std=gnu++11 --stdlib=libstdc++ -c -o somefile.o somefile.cpp";
+        let parseResult : CxxArgInfo = cxxArgParse(compilerCommandString);
+        assert.equal(parseResult.langStandard, null, "C++ language standard");
+        assert.equal(parseResult.systemRoot, null, "C++ cross compilation system root");
+        assert.equal(parseResult.crossTarget, null, "C++ cross compilation target triple");
+        assert.equal(parseResult.cxxStdLibrary, null, "C++ standard library");
+    });
+
+    test("Tolerate Invalid C++ Standard Library Flag Op. 2 (CLang)", () => {
+        let compilerCommandString : string = "clang++ -g -O2 -I. -I../src --std=gnu++11 -stdlib libstdc++ -c -o somefile.o somefile.cpp";
+        let parseResult : CxxArgInfo = cxxArgParse(compilerCommandString);
+        assert.equal(parseResult.langStandard, null, "C++ language standard");
+        assert.equal(parseResult.systemRoot, null, "C++ cross compilation system root");
+        assert.equal(parseResult.crossTarget, null, "C++ cross compilation target triple");
+        assert.equal(parseResult.cxxStdLibrary, null, "C++ standard library");
+    });
+
+    test("Success with Valid System Root Harvested", () => {
+        let compilerCommandString : string = "g++ -g -O2 -I. -I../src --sysroot=/opt/yocto/sysroots/armv7-none-linux-gnueabi -c -o somefile.o somefile.cpp";
+        let parseResult : CxxArgInfo = cxxArgParse(compilerCommandString);
+        assert.equal(parseResult.langStandard, null, "C++ language standard");
+        assert.equal(parseResult.systemRoot, "/opt/yocto/sysroots/armv7-none-linux-gnueabi", "C++ cross compilation system root");
+        assert.equal(parseResult.crossTarget, null, "C++ cross compilation target triple");
+        assert.equal(parseResult.cxxStdLibrary, null, "C++ standard library");
+    });
+
+    test("Tolerate Invalid System Root Flag", () => {
+        let compilerCommandString : string = "g++ -g -O2 -I. -I../src -sysroot /opt/yocto/sysroots/armv7-none-linux-gnueabi -c -o somefile.o somefile.cpp";
+        let parseResult : CxxArgInfo = cxxArgParse(compilerCommandString);
+        assert.equal(parseResult.langStandard, null, "C++ language standard");
+        assert.equal(parseResult.systemRoot, null, "C++ cross compilation system root");
+        assert.equal(parseResult.crossTarget, null, "C++ cross compilation target triple");
+        assert.equal(parseResult.cxxStdLibrary, null, "C++ standard library");
+    });
+
+    test("Success with Valid Target Triple Harvested Op. 1 (CLang)", () => {
+        let compilerCommandString : string = "clang++ -g -O2 -I. -I../src -target armv7-none-linux-gnueabi -c -o somefile.o somefile.cpp";
+        let parseResult : CxxArgInfo = cxxArgParse(compilerCommandString);
+        assert.equal(parseResult.langStandard, null, "C++ language standard");
+        assert.equal(parseResult.systemRoot, null, "C++ cross compilation system root");
+        assert.equal(parseResult.crossTarget, "armv7-none-linux-gnueabi", "C++ cross compilation target triple");
+        assert.equal(parseResult.cxxStdLibrary, null, "C++ standard library");
+    });
+
+    test("Success with Valid Target Triple Harvested Op. 2 (CLang)", () => {
+        let compilerCommandString : string = "clang++ -g -O2 -I. -I../src --target=armv7-none-linux-gnueabi -c -o somefile.o somefile.cpp";
+        let parseResult : CxxArgInfo = cxxArgParse(compilerCommandString);
+        assert.equal(parseResult.langStandard, null, "C++ language standard");
+        assert.equal(parseResult.systemRoot, null, "C++ cross compilation system root");
+        assert.equal(parseResult.crossTarget, "armv7-none-linux-gnueabi", "C++ cross compilation target triple");
+        assert.equal(parseResult.cxxStdLibrary, null, "C++ standard library");
+    });
+
+    test("Tolerate Invalid Target Triple Flag Op. 2 (CLang)", () => {
+        let compilerCommandString : string = "clang++ -g -O2 -I. -I../src --target armv7-none-linux-gnueabi -c -o somefile.o somefile.cpp";
+        let parseResult : CxxArgInfo = cxxArgParse(compilerCommandString);
+        assert.equal(parseResult.langStandard, null, "C++ language standard");
+        assert.equal(parseResult.systemRoot, null, "C++ cross compilation system root");
+        assert.equal(parseResult.crossTarget, null, "C++ cross compilation target triple");
+        assert.equal(parseResult.cxxStdLibrary, null, "C++ standard library");
+    });
+
+    test("Failed Parse with Missing Target Triple (CLang)", () => {
+        let compilerCommandString : string = "clang++ -g -O2 -I. -I../src -target -c -o somefile.o somefile.cpp";
+        let parseResult : CxxArgInfo = cxxArgParse(compilerCommandString);
+        assert.equal(parseResult.langStandard, null, "C++ language standard");
+        assert.equal(parseResult.systemRoot, null, "C++ cross compilation system root");
+        assert.equal(parseResult.crossTarget, "-c", "C++ cross compilation target triple");
+        assert.equal(parseResult.cxxStdLibrary, null, "C++ standard library");
+    });
+
+    test("Tolerate Invalid Target Triple Flag Op. 1 (CLang)", () => {
+        let compilerCommandString : string = "clang++ -g -O2 -I. -I../src -target=armv7-none-linux-gnueabi -c -o somefile.o somefile.cpp";
+        let parseResult : CxxArgInfo = cxxArgParse(compilerCommandString);
+        assert.equal(parseResult.langStandard, null, "C++ language standard");
+        assert.equal(parseResult.systemRoot, null, "C++ cross compilation system root");
+        assert.equal(parseResult.crossTarget, null, "C++ cross compilation target triple");
+        assert.equal(parseResult.cxxStdLibrary, null, "C++ standard library");
+    });
+
+    test("Typical Cross Compilation Line (GCC)", () => {
+        let compilerCommandString : string = "armv7-none-linux-gnueabi-g++ -g -O2 -I. -I../src --sysroot=/opt/yocto/sysroots/armv7-none-linux-gnueabi -c -o somefile.o somefile.cpp";
+        let parseResult : CxxArgInfo = cxxArgParse(compilerCommandString);
+        assert.equal(parseResult.langStandard, null, "C++ language standard");
+        assert.equal(parseResult.systemRoot, "/opt/yocto/sysroots/armv7-none-linux-gnueabi", "C++ cross compilation system root");
+        assert.equal(parseResult.crossTarget, null, "C++ cross compilation target triple");
+        assert.equal(parseResult.cxxStdLibrary, null, "C++ standard library");
+    });
+
+    test("Typical Cross Compilation Line (CLang)", () => {
+        let compilerCommandString : string = "clang++ -g -O2 -I. -I../src -target armv7-none-linux-gnueabi --sysroot=/opt/yocto/sysroots/armv7-none-linux-gnueabi -c -o somefile.o somefile.cpp";
+        let parseResult : CxxArgInfo = cxxArgParse(compilerCommandString);
+        assert.equal(parseResult.langStandard, null, "C++ language standard");
+        assert.equal(parseResult.systemRoot, "/opt/yocto/sysroots/armv7-none-linux-gnueabi", "C++ cross compilation system root");
+        assert.equal(parseResult.crossTarget, "armv7-none-linux-gnueabi", "C++ cross compilation target triple");
+        assert.equal(parseResult.cxxStdLibrary, null, "C++ standard library");
+    });
+
+    test("Typical Cross Compilation Line (GCC)", () => {
+        let compilerCommandString : string = "armv7-none-linux-gnueabi-g++ -g -O2 -I. -I../src --sysroot=/opt/yocto/sysroots/armv7-none-linux-gnueabi -c -o somefile.o somefile.cpp";
+        let parseResult : CxxArgInfo = cxxArgParse(compilerCommandString);
+        assert.equal(parseResult.langStandard, null, "C++ language standard");
+        assert.equal(parseResult.systemRoot, "/opt/yocto/sysroots/armv7-none-linux-gnueabi", "C++ cross compilation system root");
+        assert.equal(parseResult.crossTarget, null, "C++ cross compilation target triple");
+        assert.equal(parseResult.cxxStdLibrary, null, "C++ standard library");
+    });
+
+    test("Typical Cross Compilation Line (CLang)", () => {
+        let compilerCommandString : string = "clang++ -g -O2 -I. -I../src -target armv7-none-linux-gnueabi --sysroot=/opt/yocto/sysroots/armv7-none-linux-gnueabi -c -o somefile.o somefile.cpp";
+        let parseResult : CxxArgInfo = cxxArgParse(compilerCommandString);
+        assert.equal(parseResult.langStandard, null, "C++ language standard");
+        assert.equal(parseResult.systemRoot, "/opt/yocto/sysroots/armv7-none-linux-gnueabi", "C++ cross compilation system root");
+        assert.equal(parseResult.crossTarget, "armv7-none-linux-gnueabi", "C++ cross compilation target triple");
+        assert.equal(parseResult.cxxStdLibrary, null, "C++ standard library");
+    });
+
+    test("Maximum Harvest (GCC)", () => {
+        let compilerCommandString : string = "armv7-none-linux-gnueabi-g++ -g -O2 -I. -I../src -std=gnu++17 --sysroot=/opt/yocto/sysroots/armv7-none-linux-gnueabi -c -o somefile.o somefile.cpp";
+        let parseResult : CxxArgInfo = cxxArgParse(compilerCommandString);
+        assert.equal(parseResult.langStandard, "gnu++17", "C++ language standard");
+        assert.equal(parseResult.systemRoot, "/opt/yocto/sysroots/armv7-none-linux-gnueabi", "C++ cross compilation system root");
+        assert.equal(parseResult.crossTarget, null, "C++ cross compilation target triple");
+        assert.equal(parseResult.cxxStdLibrary, null, "C++ standard library");
+    });
+
+    test("Maximum Harvest (CLang)", () => {
+        let compilerCommandString : string = "clang++ -g -O2 -I. -I../src -target armv7-none-linux-gnueabi -std=gnu++17 -stdlib=libc++ --sysroot=/opt/yocto/sysroots/armv7-none-linux-gnueabi -c -o somefile.o somefile.cpp";
+        let parseResult : CxxArgInfo = cxxArgParse(compilerCommandString);
+        assert.equal(parseResult.langStandard, "gnu++17", "C++ language standard");
+        assert.equal(parseResult.systemRoot, "/opt/yocto/sysroots/armv7-none-linux-gnueabi", "C++ cross compilation system root");
+        assert.equal(parseResult.crossTarget, "armv7-none-linux-gnueabi", "C++ cross compilation target triple");
+        assert.equal(parseResult.cxxStdLibrary, "libc++", "C++ standard library");
+    });
+});

--- a/src/test/cxx_arg_parse.test.ts
+++ b/src/test/cxx_arg_parse.test.ts
@@ -2,6 +2,11 @@ import * as assert from 'assert';
 
 import { CxxArgInfo, cxxArgParse } from '../cxx_arg_parse';
 
+/**
+ * Test suite for the `cxxArgParse()` function.
+ * 
+ * @author Rolando J. Nieves
+ */
 suite("C++ Compiler Argument Parsing Tests", () => {
     test("Simple with Nothing Harvested", () => {
         let compilerCommandString : string = "g++ -g -O2 -I. -I../src -c -o somefile.o somefile.cpp";


### PR DESCRIPTION
This pull request contains a refactoring of the compile command parsing. The primary motivation for this fork was the fact that the CMake Ninja generator prefers using relative paths when describing directories for the preprocessor standard include path. Unfortunately, when the CLang scanner runs, its current working directory sometimes does not meet the expectations implied by the CMake Ninja generator. Even when specifying the include path directories manually as absolute paths in the CMakeLists.txt file, the CMake Ninja generator still converts these to relative paths whenever possible. The modifications in this pull request do a deep dive into all of the compile command arguments, only including those that have a material impact on the scan done by CLang. When this logic encounters relative paths in the include search, it will expand them using the information provided in CMake's compile_commands.json file.

Since the amount of code added was significant, I found it prudent to also include Mocha unit test suites for all of the new functions and classes added to the extension's source code base. As of this writing, all 67 unit tests are passing. I've also tested the revised extension with my C++ projects, and the original intended goal of the extension works well. There's also thorough documentation on all added and modified code.